### PR TITLE
Update server.lua

### DIFF
--- a/gum_metabolism/server.lua
+++ b/gum_metabolism/server.lua
@@ -1,13 +1,12 @@
-gumCore = {}
-
+local gumCore = {}
 TriggerEvent("getCore",function(core)
-	gumCore = core
+    gumCore = core
 end)
-gum = exports.gum_core:gumAPI()
 
-	
 Inventory = exports.gum_inventory:gum_inventoryApi()
 gum = exports.gum_core:gumAPI()
+
+
 local blockSpamItems = {}
 local metaDataCache = {}
 for a,b in pairs(Config.Metabolism) do


### PR DESCRIPTION
Had duplicate gum = exports.gum_core:gumAPI() 
And was missing Local gumCore= {} not sure if local was supposed to be missing.

Was pulling errors with the Local missing, changed to correct api from natives and no longer pulling errors